### PR TITLE
Fix game freezing after clearing final stage

### DIFF
--- a/src/game_state_complete.py
+++ b/src/game_state_complete.py
@@ -27,7 +27,7 @@ class GameStateComplete:
         self.scroll_x = 0
 
         self.music = load_music(MUSIC_GAME_COMPLETE)
-        play_music(self.music, loop=True, num_channels=3)
+        play_music(self.music, True, num_channels=3)
     
     def on_exit(self):
         stop_music(3)


### PR DESCRIPTION
Currently, after beating the final boss, the game client will crash with error `TypeError: play_music() got an unexpected keyword argument 'loop'`. 
This PR should resolve the issue and allow the player to view the victory screen.